### PR TITLE
fix: traverse one more level to get value of the node

### DIFF
--- a/packages/plugin-json/src/lib/amplience-schema-transformers.ts
+++ b/packages/plugin-json/src/lib/amplience-schema-transformers.ts
@@ -371,7 +371,7 @@ export const filterableTrait = (type: ObjectTypeDefinitionNode) => {
   if (filterableProps.length > 5)
     throw new Error('max @filterable tags can be five')
   const filterCombinations = combinations(
-    filterableProps.map(s => `/${s.name}`)
+    filterableProps.map(s => `/${s.name.value}`)
   )
 
   return {


### PR DESCRIPTION
Fixed filterable trait to fetch node value instead of just the Node Object

Before:
![image](https://user-images.githubusercontent.com/107406547/187365546-baefe184-b130-42f2-a54e-91dfb49b057d.png)
After:
![image](https://user-images.githubusercontent.com/107406547/187365601-3a12aa31-626f-4e3f-baba-9c268d5f63cc.png)
