### PR TITLE
remove required_providers from generated file

### DIFF
--- a/packages/plugin-terraform/examples/output/example.tf
+++ b/packages/plugin-terraform/examples/output/example.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    amplience = {
-      source = "labd/amplience"
-    }
-  }
-}
-
 data "amplience_content_repository" "website1" {
   id = var.variables["CONTENT_REPO1_ID"]
 }

--- a/packages/plugin-terraform/src/index.ts
+++ b/packages/plugin-terraform/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { schemaPrepend } from 'amplience-graphql-codegen-common'
 import { snakeCase } from 'change-case'
 import { GraphQLSchema, visit } from 'graphql'
-import { map, TerraformGenerator } from 'terraform-generator'
+import { TerraformGenerator } from 'terraform-generator'
 import { createObjectTypeVisitor, maybeArg } from './lib/visitor'
 import { PluginConfig } from './lib/config'
 
@@ -28,9 +28,7 @@ export const plugin: PluginFunction<PluginConfig> = (
   const astNode = getCachedDocumentNodeFromSchema(schema)
 
   // This class can build a terraform file string.
-  const tfg = new TerraformGenerator({
-    required_providers: { amplience: map({ source: 'labd/amplience' }) },
-  })
+  const tfg = new TerraformGenerator()
 
   // To connect the Amplience content type resources to the correct Amplience repository,
   // we first generate the terraform repositories as terraform data.

--- a/packages/plugin-terraform/test/testdata/expected/base.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base.tf
@@ -1,11 +1,3 @@
-terraform {
-required_providers {
-amplience = {
-source = "labd/amplience"
-}
-}
-}
-
 data "amplience_content_repository" "website1"{
 id = var.variables["CONTENT_REPO1_ID"]
 }


### PR DESCRIPTION
Purpose: to allow flexibility of the consumer to define their own required_providers in their terraform module since it's unique to a module, if we enforce consumer to only depend on this, it will be a nuisance since they will be unable to modify the generated content