### PR TITLE
feat: switch case library

### DIFF
--- a/.changeset/slimy-peas-double.md
+++ b/.changeset/slimy-peas-double.md
@@ -1,0 +1,7 @@
+---
+"amplience-graphql-codegen-terraform": patch
+"amplience-graphql-codegen-json": patch
+"amplience-graphql-codegen-common": patch
+---
+
+use change-case-all instead of change-case

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "change-case": "^4.1.2",
+    "change-case-all": "^1.0.15",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6"
   },

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-import { paramCase } from "change-case";
+import { paramCase } from "change-case-all";
 import { TypeDefinitionNode } from "graphql";
 
 export * from "./graphql";

--- a/packages/plugin-json/package.json
+++ b/packages/plugin-json/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^5.0.1",
     "amplience-graphql-codegen-common": "^1.0.18",
-    "change-case": "^4.1.2",
+    "change-case-all": "^1.0.15",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6"
   },

--- a/packages/plugin-json/src/index.ts
+++ b/packages/plugin-json/src/index.ts
@@ -9,7 +9,7 @@ import {
   isObjectTypeDefinitionNode,
   schemaPrepend,
 } from "amplience-graphql-codegen-common";
-import { paramCase } from "change-case";
+import { paramCase } from "change-case-all";
 import { ObjectTypeDefinitionNode } from "graphql";
 import { contentTypeSchemaBody } from "./lib/amplience-schema-transformers";
 import {
@@ -40,7 +40,7 @@ export const plugin: PluginFunction<PluginConfig> = (
   schema,
   _documents,
   { hostname = "https://schema-examples.com" },
-  info
+  info,
 ) => {
   const node = info?.pluginContext?.typeNode as ObjectTypeDefinitionNode;
 
@@ -52,21 +52,21 @@ export const validate: PluginValidateFn<PluginConfig> = (
   schema,
   _documents,
   _config,
-  _outputFile
+  _outputFile,
 ) => {
   const types = getObjectTypeDefinitions(schema);
   const requiredLocalizedFieldsReport = getRequiredLocalizedFieldsReport(types);
 
   if (requiredLocalizedFieldsReport.length) {
     throw new Error(
-      `Fields with '@amplienceLocalized' must be Nullable.\n\n${requiredLocalizedFieldsReport}`
+      `Fields with '@amplienceLocalized' must be Nullable.\n\n${requiredLocalizedFieldsReport}`,
     );
   }
 
   const tooManyFiltersReport = getTooManyFiltersReport(types);
   if (tooManyFiltersReport.length) {
     throw new Error(
-      `Types can have no more than 5 fields with '@amplienceFiltered'.\n\n${tooManyFiltersReport}`
+      `Types can have no more than 5 fields with '@amplienceFiltered'.\n\n${tooManyFiltersReport}`,
     );
   }
 };
@@ -79,10 +79,9 @@ export const preset: Types.OutputPreset<PresetConfig> = {
       .map((node) => ({
         ...options,
         filename: `${dirname(options.baseOutputDir)}/schemas/${paramCase(
-          node.name.value
-        )}${
-          options.config.schemaSuffix ? "-" + options.config.schemaSuffix : ""
-        }.json`,
+          node.name.value,
+        )}${options.config.schemaSuffix ? "-" + options.config.schemaSuffix : ""
+          }.json`,
 
         pluginContext: {
           typeNode: node,

--- a/packages/plugin-json/src/lib/amplience-schema-transformers.ts
+++ b/packages/plugin-json/src/lib/amplience-schema-transformers.ts
@@ -9,8 +9,8 @@ import {
   switchArray,
   typeName,
   typeUri,
-} from 'amplience-graphql-codegen-common'
-import { capitalCase, paramCase } from 'change-case'
+} from "amplience-graphql-codegen-common";
+import { capitalCase, paramCase } from "change-case-all";
 import {
   EnumValueNode,
   FieldDefinitionNode,
@@ -25,8 +25,8 @@ import {
   isEnumType,
   isObjectType,
   isUnionType,
-} from 'graphql'
-import { AmplienceContentTypeSchemaBody, AmpliencePropertyType } from './types'
+} from "graphql";
+import { AmplienceContentTypeSchemaBody, AmpliencePropertyType } from "./types";
 
 /**
  * Returns a Amplience ContentType from an interface type.
@@ -34,7 +34,7 @@ import { AmplienceContentTypeSchemaBody, AmpliencePropertyType } from './types'
 export const contentTypeSchemaBody = (
   type: ObjectTypeDefinitionNode,
   schema: GraphQLSchema,
-  schemaHost: string
+  schemaHost: string,
 ): AmplienceContentTypeSchemaBody => ({
   $id: typeUri(type, schemaHost),
   $schema: "http://json-schema.org/draft-07/schema#",
@@ -59,16 +59,16 @@ export const contentTypeSchemaBody = (
     .filter(
       (field) =>
         field.type.kind === "NonNullType" ||
-        hasDirective(field, "amplienceLocalized")
+        hasDirective(field, "amplienceLocalized"),
     )
     .map((n) => n.name.value),
   ...(isHierarchy(type)
     ? {
-        allOf: [
-          refType(AMPLIENCE_TYPE.CORE.Content).allOf[0],
-          refType(AMPLIENCE_TYPE.CORE.HierarchyNode).allOf[0],
-        ],
-      }
+      allOf: [
+        refType(AMPLIENCE_TYPE.CORE.Content).allOf[0],
+        refType(AMPLIENCE_TYPE.CORE.HierarchyNode).allOf[0],
+      ],
+    }
     : {}),
 });
 
@@ -78,7 +78,7 @@ export const contentTypeSchemaBody = (
 export const objectProperties = (
   type: ObjectTypeDefinitionNode,
   schema: GraphQLSchema,
-  schemaHost: string
+  schemaHost: string,
 ): { [name: string]: AmpliencePropertyType } =>
   Object.fromEntries(
     type.fields
@@ -94,16 +94,18 @@ export const objectProperties = (
               minItems: ifValue(
                 ifValue(
                   maybeDirective(prop, "amplienceList"),
-                  (d) => maybeDirectiveValue<IntValueNode>(d, "minItems")?.value
+                  (d) =>
+                    maybeDirectiveValue<IntValueNode>(d, "minItems")?.value,
                 ),
-                Number
+                Number,
               ),
               maxItems: ifValue(
                 ifValue(
                   maybeDirective(prop, "amplienceList"),
-                  (d) => maybeDirectiveValue<IntValueNode>(d, "maxItems")?.value
+                  (d) =>
+                    maybeDirectiveValue<IntValueNode>(d, "maxItems")?.value,
                 ),
-                Number
+                Number,
               ),
               items: ampliencePropertyType(prop, subType, schema, schemaHost),
               const: arrayConstValues(prop),
@@ -112,27 +114,29 @@ export const objectProperties = (
               ampliencePropertyType(prop, type, schema, schemaHost),
           }),
         },
-      ]) ?? []
+      ]) ?? [],
   );
 
 const isHierarchy = (type: ObjectTypeDefinitionNode) =>
   maybeDirectiveValue<EnumValueNode>(
     maybeDirective(type, "amplienceContentType")!,
-    "kind"
+    "kind",
   )?.value === "HIERARCHY";
 
 const isAmplienceProperty = (
   type: ObjectTypeDefinitionNode,
-  field: FieldDefinitionNode
+  field: FieldDefinitionNode,
 ) =>
   !hasDirective(field, "amplienceIgnore") &&
   (!isHierarchy(type) || field.name.value !== "children");
 
 const arrayConstValues = (prop: FieldDefinitionNode) =>
-  ifValue(maybeDirective(prop, "amplienceConst"), (d) =>
-    maybeDirectiveValue<ListValueNode>(d, "items")?.values.map(
-      (v) => (v as StringValueNode)?.value
-    )
+  ifValue(
+    maybeDirective(prop, "amplienceConst"),
+    (d) =>
+      maybeDirectiveValue<ListValueNode>(d, "items")?.values.map(
+        (v) => (v as StringValueNode)?.value,
+      ),
   );
 
 /**
@@ -142,7 +146,7 @@ export const ampliencePropertyType = (
   prop: FieldDefinitionNode,
   type: TypeNode,
   schema: GraphQLSchema,
-  schemaHost: string
+  schemaHost: string,
 ): AmpliencePropertyType => {
   const node = schema.getType(typeName(type));
   // Handle non-primitive types.
@@ -166,11 +170,11 @@ export const ampliencePropertyType = (
         return contentReference(node.astNode, schemaHost);
       }
 
-      if (hasDirective(node.astNode, 'amplienceContentType')) {
-        return inlineContentReference(node.astNode, schemaHost)
+      if (hasDirective(node.astNode, "amplienceContentType")) {
+        return inlineContentReference(node.astNode, schemaHost);
       }
 
-      return inlineObject(node.astNode, schema, schemaHost)
+      return inlineObject(node.astNode, schema, schemaHost);
     }
   }
 
@@ -178,7 +182,7 @@ export const ampliencePropertyType = (
   switch (typeName(type)) {
     case "String":
       const constValue = ifValue(maybeDirective(prop, "amplienceConst"), (d) =>
-        maybeDirectiveValue<StringValueNode>(d, "item")
+        maybeDirectiveValue<StringValueNode>(d, "item"),
       )?.value;
 
       // Special case for const values.
@@ -197,15 +201,15 @@ export const ampliencePropertyType = (
           pattern: maybeDirectiveValue<StringValueNode>(d, "pattern")?.value,
           minLength: ifValue(
             maybeDirectiveValue<IntValueNode>(d, "minLength")?.value,
-            Number
+            Number,
           ),
           maxLength: ifValue(
             maybeDirectiveValue<IntValueNode>(d, "maxLength")?.value,
-            Number
+            Number,
           ),
           examples: maybeDirectiveValue<ListValueNode>(
             d,
-            "examples"
+            "examples",
           )?.values.map((v) => (v as StringValueNode)?.value),
         })),
       });
@@ -219,11 +223,11 @@ export const ampliencePropertyType = (
           format: maybeDirectiveValue<StringValueNode>(d, "format")?.value,
           minimum: ifValue(
             maybeDirectiveValue<IntValueNode>(d, "minimum")?.value,
-            Number
+            Number,
           ),
           maximum: ifValue(
             maybeDirectiveValue<IntValueNode>(d, "maximum")?.value,
-            Number
+            Number,
           ),
         })),
       });
@@ -231,15 +235,15 @@ export const ampliencePropertyType = (
     case "AmplienceVideo":
       return hasDirective(prop, "amplienceLocalized")
         ? refType(
-            AMPLIENCE_TYPE.LOCALIZED[
-              typeName(type) as "AmplienceImage" | "AmplienceVideo"
-            ]
-          )
+          AMPLIENCE_TYPE.LOCALIZED[
+          typeName(type) as "AmplienceImage" | "AmplienceVideo"
+          ],
+        )
         : refType(
-            AMPLIENCE_TYPE.CORE[
-              typeName(type) as "AmplienceImage" | "AmplienceVideo"
-            ]
-          );
+          AMPLIENCE_TYPE.CORE[
+          typeName(type) as "AmplienceImage" | "AmplienceVideo"
+          ],
+        );
   }
   return {};
 };
@@ -247,17 +251,17 @@ export const ampliencePropertyType = (
 const contentReference = (type: ObjectTypeDefinitionNode, schemaHost: string) =>
   refType(
     AMPLIENCE_TYPE.CORE.ContentReference,
-    enumProperties(type, schemaHost)
+    enumProperties(type, schemaHost),
   );
 
 const contentLink = (
   type: UnionTypeDefinitionNode | ObjectTypeDefinitionNode,
-  schemaHost: string
+  schemaHost: string,
 ) => refType(AMPLIENCE_TYPE.CORE.ContentLink, enumProperties(type, schemaHost));
 
 const enumProperties = (
   typeOrUnion: TypeDefinitionNode,
-  schemaHost: string
+  schemaHost: string,
 ) => ({
   properties: {
     contentType: {
@@ -272,19 +276,19 @@ const enumProperties = (
 const inlineObject = (
   type: ObjectTypeDefinitionNode,
   schema: GraphQLSchema,
-  schemaHost: string
+  schemaHost: string,
 ) => ({
-  type: 'object',
+  type: "object",
   properties: objectProperties(type, schema, schemaHost),
   propertyOrder: type.fields?.map((n) => n.name.value),
   required: type.fields
-    ?.filter((field) => field.type.kind === 'NonNullType')
+    ?.filter((field) => field.type.kind === "NonNullType")
     .map((field) => field.name.value),
-})
+});
 
 const inlineContentReference = (
   type: ObjectTypeDefinitionNode,
-  schemaHost: string
+  schemaHost: string,
 ) => ({
   type: "object",
   // use inline content (https://amplience.com/developers/docs/schema-reference/data-types/#inline-content)
@@ -298,7 +302,7 @@ const inlineContentReference = (
 export const checkLocalized = (
   prop: FieldDefinitionNode,
   type: TypeNode,
-  result: AmpliencePropertyType
+  result: AmpliencePropertyType,
 ) =>
   hasDirective(prop, "amplienceLocalized")
     ? prop.directives?.length === 1 && typeName(type) === "String"
@@ -363,7 +367,7 @@ export const sortableTrait = (type: ObjectTypeDefinitionNode) =>
           paths: items.map((n) => `/${n.name.value}`),
         },
       ],
-    })
+    }),
   );
 
 /**
@@ -374,7 +378,7 @@ export const sortableTrait = (type: ObjectTypeDefinitionNode) =>
 export const hierarchyTrait = (
   type: ObjectTypeDefinitionNode,
   schema: GraphQLSchema,
-  schemaHost: string
+  schemaHost: string,
 ) => ({
   childContentTypes: type.fields
     ?.filter((field) => field.name.value === "children")
@@ -403,7 +407,7 @@ export const filterableTrait = (type: ObjectTypeDefinitionNode) => {
 
   return {
     filterBy: combinations(filterableProps.map((s) => `/${s.name.value}`)).map(
-      (paths) => ({ paths })
+      (paths) => ({ paths }),
     ),
   };
 };

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^5.0.1",
     "amplience-graphql-codegen-common": "^1.0.18",
-    "change-case": "^4.1.2",
+    "change-case-all": "^1.0.15",
     "graphql": "^16.8.1",
     "terraform-generator": "^5.3.2"
   },

--- a/packages/plugin-terraform/src/index.ts
+++ b/packages/plugin-terraform/src/index.ts
@@ -6,7 +6,7 @@ import {
   Types,
 } from "@graphql-codegen/plugin-helpers";
 import { schemaPrepend } from "amplience-graphql-codegen-common";
-import { snakeCase } from "change-case";
+import { snakeCase } from "change-case-all";
 import { GraphQLSchema, visit } from "graphql";
 import { map, TerraformGenerator } from "terraform-generator";
 import { createObjectTypeVisitor, maybeArg } from "./lib/visitor";
@@ -24,7 +24,7 @@ export const plugin: PluginFunction<PluginConfig> = (
     slot_repositories,
     schemaSuffix,
     add_required_provider = true,
-  }
+  },
 ) => {
   const astNode = getCachedDocumentNodeFromSchema(schema);
 
@@ -32,34 +32,34 @@ export const plugin: PluginFunction<PluginConfig> = (
   const tfg = new TerraformGenerator(
     add_required_provider
       ? {
-          required_providers: { amplience: map({ source: 'labd/amplience' }) },
-        }
-      : undefined
-  )
+        required_providers: { amplience: map({ source: "labd/amplience" }) },
+      }
+      : undefined,
+  );
 
   // To connect the Amplience content type resources to the correct Amplience repository,
   // we first generate the terraform repositories as terraform data.
   const contentRepositories = content_repositories
     ? Object.entries(content_repositories)
-        .filter(([name]) => name !== 'for_each')
-        .map(([name, value]) =>
-          tfg.data('amplience_content_repository', snakeCase(name), {
-            id: maybeArg(value),
-          })
-        )
-    : undefined
+      .filter(([name]) => name !== "for_each")
+      .map(([name, value]) =>
+        tfg.data("amplience_content_repository", snakeCase(name), {
+          id: maybeArg(value),
+        }),
+      )
+    : undefined;
   const slotRepositories = slot_repositories
     ? Object.entries(slot_repositories)
-        .filter(([name]) => name !== 'for_each')
-        .map(([name, value]) =>
-          tfg.data('amplience_content_repository', snakeCase(name), {
-            id: maybeArg(value),
-          })
-        )
-    : undefined
+      .filter(([name]) => name !== "for_each")
+      .map(([name, value]) =>
+        tfg.data("amplience_content_repository", snakeCase(name), {
+          id: maybeArg(value),
+        }),
+      )
+    : undefined;
 
-  const slotRepositoriesForEach = slot_repositories?.for_each
-  const contentRepositoriesForEach = content_repositories?.for_each
+  const slotRepositoriesForEach = slot_repositories?.for_each;
+  const contentRepositoriesForEach = content_repositories?.for_each;
 
   // For each GraphQl object type, add corresponding resources to the terraform generator.
   visit(astNode, {
@@ -85,17 +85,17 @@ export const validate: PluginValidateFn<any> = async (
   _schema: GraphQLSchema,
   _documents: Types.DocumentFile[],
   config: PluginConfig,
-  outputFile: string
+  outputFile: string,
 ) => {
   if (extname(outputFile) !== ".tf") {
     throw new Error(
-      `Plugin "amplience-terraform" requires output extension to be ".tf"!`
+      `Plugin "amplience-terraform" requires output extension to be ".tf"!`,
     );
   }
   if (config.visualization) {
     if (config.visualization.filter((v) => v.for_each).length > 1) {
       throw new Error(
-        `You can only have 1 item with a for_each property in your visualization list.`
+        `You can only have 1 item with a for_each property in your visualization list.`,
       );
     }
     if (
@@ -103,25 +103,25 @@ export const validate: PluginValidateFn<any> = async (
       config.visualization.some((v) => v.default && v.for_each)
     ) {
       throw new Error(
-        `You can only set 1 item, which may not be a for_each-item to be the default.`
+        `You can only set 1 item, which may not be a for_each-item to be the default.`,
       );
     }
   }
   if (config.content_repositories) {
-    validateRepositoryConfig(config.content_repositories)
+    validateRepositoryConfig(config.content_repositories);
   }
 
   if (config.slot_repositories) {
-    validateRepositoryConfig(config.slot_repositories)
+    validateRepositoryConfig(config.slot_repositories);
   }
-}
+};
 
 function validateRepositoryConfig(repositoryMap: { [name: string]: string }) {
-  const repositoryKeys = Object.keys(repositoryMap)
+  const repositoryKeys = Object.keys(repositoryMap);
 
   if (repositoryKeys.length > 1 && repositoryMap.for_each) {
     throw new Error(
-      `for_each should not be used when multiple repositories are defined to prevent duplicate resources.`
-    )
+      `for_each should not be used when multiple repositories are defined to prevent duplicate resources.`,
+    );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,9 @@ importers:
 
   packages/common:
     dependencies:
-      change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
+      change-case-all:
+        specifier: ^1.0.15
+        version: 1.0.15
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -70,9 +70,9 @@ importers:
       amplience-graphql-codegen-common:
         specifier: ^1.0.18
         version: link:../common
-      change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
+      change-case-all:
+        specifier: ^1.0.15
+        version: 1.0.15
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -88,9 +88,9 @@ importers:
       amplience-graphql-codegen-common:
         specifier: ^1.0.18
         version: link:../common
-      change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
+      change-case-all:
+        specifier: ^1.0.15
+        version: 1.0.15
       graphql:
         specifier: ^16.8.1
         version: 16.8.1


### PR DESCRIPTION
The `change-case` library has recently gone full ESM which makes it incompatible with our current setup. This PR switches out the `change-case` library with the `change-case-all` library which does work with our setup.

Relevant Dependabot PR: https://github.com/labd/graphql-codegen-plugin-amplience/pull/61