### PR TITLE
Feat: amplience delivery key directive

### DIFF
--- a/example/example.graphql
+++ b/example/example.graphql
@@ -25,6 +25,12 @@ type Base @amplienceContentType {
   union: Union
   linkedA: A @amplienceLink
   referencedB: B @amplienceReference
+  deliveryKey: String
+    @amplienceDeliveryKey(
+      title: "example title"
+      description: "example description"
+      pattern: "some-pattern/requirement"
+    )
 }
 
 enum Enum {

--- a/packages/common/src/directives.ts
+++ b/packages/common/src/directives.ts
@@ -21,6 +21,7 @@ export const schemaPrepend = gql`
   directive @amplienceIgnore on FIELD_DEFINITION | SCALAR | OBJECT
   directive @amplienceSortable on FIELD_DEFINITION
   directive @amplienceFilterable on FIELD_DEFINITION
+  directive @amplienceDeliveryKey(title: String, description: String, pattern: String) on FIELD_DEFINITION
 
   enum ValidationLevel {
     SLOT

--- a/packages/plugin-json/README.md
+++ b/packages/plugin-json/README.md
@@ -151,3 +151,27 @@ type MyContentType @amplienceContentType {
   constArray: [String!]! @amplienceConst(items: ["this", "is", "const"])
 }
 ```
+
+## @amplienceDeliveryKey
+
+Adds a delivery key field to the Content Type form. Only works on `String` types.
+
+[See documentation](https://amplience.com/developers/docs/dev-tools/guides-tutorials/delivery-keys/#including-the-deliverykey-property-in-a-content-type-schema)
+
+```graphql
+type MyContentType @amplienceContentType {
+  deliveryKey: String
+    @amplienceDeliveryKey(
+      # Optional field title
+      # Default value: 'Delivery Key'
+      title: "example title"
+
+      # Optional field description
+      # Default value: 'Set a delivery key for this content item'
+      description: "Format: delivery-key/format/requirement"
+
+      # Optional field validation pattern
+      pattern: "delivery-key/format/requirement"
+    )
+}
+```

--- a/packages/plugin-json/examples/output/schemas/test.json
+++ b/packages/plugin-json/examples/output/schemas/test.json
@@ -11,10 +11,22 @@
       "title": "Name",
       "description": "This a description",
       "type": "string"
+    },
+    "_meta": {
+      "type": "object",
+      "title": "Delivery Key",
+      "properties": {
+        "deliveryKey": {
+          "type": "string",
+          "title": "test title",
+          "description": "test description",
+          "pattern": "test pattern"
+        }
+      }
     }
   },
   "description": "Test",
   "type": "object",
-  "propertyOrder": ["bla", "name"],
+  "propertyOrder": ["_meta", "bla", "name"],
   "required": ["bla"]
 }

--- a/packages/plugin-json/examples/output/schemas/test2.json
+++ b/packages/plugin-json/examples/output/schemas/test2.json
@@ -11,32 +11,14 @@
       "type": "array",
       "items": {
         "type": "object",
-        "properties": {
-          "bla": { "title": "Bla", "type": "integer" },
-          "name": {
-            "title": "Name",
-            "description": "This a description",
-            "type": "string"
-          }
-        },
-        "propertyOrder": ["bla", "name"],
-        "required": ["bla"]
+        "allOf": [{ "$ref": "https://schema-examples.com/test" }]
       }
     },
     "name": { "title": "Name", "type": "string" },
     "test": {
       "title": "Test",
       "type": "object",
-      "properties": {
-        "bla": { "title": "Bla", "type": "integer" },
-        "name": {
-          "title": "Name",
-          "description": "This a description",
-          "type": "string"
-        }
-      },
-      "propertyOrder": ["bla", "name"],
-      "required": ["bla"]
+      "allOf": [{ "$ref": "https://schema-examples.com/test" }]
     }
   },
   "description": "Test2",

--- a/packages/plugin-json/examples/schema.graphql
+++ b/packages/plugin-json/examples/schema.graphql
@@ -5,6 +5,13 @@ type Test @amplienceContentType {
   name: String
 
   bla: Int!
+
+  deliveryKey: String
+    @amplienceDeliveryKey(
+      title: "test title"
+      description: "test description"
+      pattern: "test pattern"
+    )
 }
 
 type Test2 @amplienceContentType {

--- a/packages/plugin-json/src/index.ts
+++ b/packages/plugin-json/src/index.ts
@@ -13,8 +13,10 @@ import { paramCase } from "change-case";
 import { ObjectTypeDefinitionNode } from "graphql";
 import { contentTypeSchemaBody } from "./lib/amplience-schema-transformers";
 import {
+  getDeliveryKeyNotNullableStringReport,
   getObjectTypeDefinitions,
   getRequiredLocalizedFieldsReport,
+  getTooManyDeliveryKeysReport,
   getTooManyFiltersReport,
 } from "./lib/validation";
 
@@ -68,6 +70,20 @@ export const validate: PluginValidateFn<PluginConfig> = (
     throw new Error(
       `Types can have no more than 5 fields with '@amplienceFiltered'.\n\n${tooManyFiltersReport}`
     );
+  }
+
+  const tooManyDeliveryKeysReport = getTooManyDeliveryKeysReport(types);
+  if (tooManyDeliveryKeysReport) {
+    throw new Error(
+      `Types can only have 1 field with '@amplienceDeliveryKey'.\n\n${tooManyDeliveryKeysReport}`
+    )
+  }
+
+  const deliveryKeyNotNullableStringReport = getDeliveryKeyNotNullableStringReport(types);
+  if (deliveryKeyNotNullableStringReport) {
+    throw new Error(
+      `Fields with '@amplienceDeliveryKey' must be of Nullable type String.\n\n${deliveryKeyNotNullableStringReport}`
+    )
   }
 };
 

--- a/packages/plugin-json/src/lib/types.ts
+++ b/packages/plugin-json/src/lib/types.ts
@@ -19,6 +19,19 @@ export interface AmpliencePropertyType {
   examples?: string[];
 }
 
+export type AmplienceDeliveryKeyType = {
+  type: 'object',
+  title: 'Delivery Key'
+  properties: {
+    deliveryKey: {
+      type: 'string'
+      title: string
+      description: string
+      pattern?: string
+    }
+  }
+}
+
 export interface AmplienceContentTypeSchemaBody {
   $id: string;
   $schema: string;
@@ -29,7 +42,7 @@ export interface AmplienceContentTypeSchemaBody {
   "trait:hierarchy"?: {};
   "trait:sortable"?: {};
   type: "object";
-  properties?: { [name: string]: AmpliencePropertyType };
+  properties?: {[name: string | '_meta']: AmpliencePropertyType | AmplienceDeliveryKeyType | undefined};
   definitions?: { [name: string]: AmpliencePropertyType };
   propertyOrder?: string[];
   required?: string[];

--- a/packages/plugin-json/src/lib/validation.ts
+++ b/packages/plugin-json/src/lib/validation.ts
@@ -39,34 +39,34 @@ const isNonNullLocalizedField = (field: FieldDefinitionNode) =>
 export const getTooManyFiltersReport = (types: ObjectTypeDefinitionNode[]) =>
   getFieldsReport(
     types.filter(
-      (type) => (type.fields?.filter(filterableField)?.length ?? 0) > 5
+      (type) => (type.fields?.filter(isFilterableField).length ?? 0) > 5
     ),
-    filterableField
+    isFilterableField
   );
 
-const filterableField = (field: FieldDefinitionNode) =>
+const isFilterableField = (field: FieldDefinitionNode) =>
   hasDirective(field, "amplienceFilterable");
 
 export const getTooManyDeliveryKeysReport = (types: ObjectTypeDefinitionNode[]) =>
   getFieldsReport(
     types.filter(
-      (type) => (type.fields?.filter(deliveryKeyField)?.length ?? 0) > 1
+      (type) => (type.fields?.filter(isDeliveryKeyField).length ?? 0) > 1
     ),
-    deliveryKeyField
+    isDeliveryKeyField
   )
 
 export const getDeliveryKeyNotNullableStringReport = (types: ObjectTypeDefinitionNode[]) =>
   getFieldsReport(
     types.filter(
-      (type) => type.fields?.some((field) => deliveryKeyField(field) && !nullableStringField(field))
+      (type) => type.fields?.some((field) => isDeliveryKeyField(field) && !isNullableStringField(field))
     ),
-    (field) => deliveryKeyField(field) && !nullableStringField(field)
+    (field) => isDeliveryKeyField(field) && !isNullableStringField(field)
   )
 
-const deliveryKeyField = (field: FieldDefinitionNode) =>
+const isDeliveryKeyField = (field: FieldDefinitionNode) =>
   hasDirective(field, 'amplienceDeliveryKey')
 
-const nullableStringField = (field: FieldDefinitionNode) =>
+const isNullableStringField = (field: FieldDefinitionNode) =>
   (
     field.type.kind === 'NamedType' &&
     field.type.name.value === 'String'

--- a/packages/plugin-json/src/lib/validation.ts
+++ b/packages/plugin-json/src/lib/validation.ts
@@ -39,13 +39,38 @@ const isNonNullLocalizedField = (field: FieldDefinitionNode) =>
 export const getTooManyFiltersReport = (types: ObjectTypeDefinitionNode[]) =>
   getFieldsReport(
     types.filter(
-      (type) => (type.fields?.filter(filterableField).length ?? 0) > 5
+      (type) => (type.fields?.filter(filterableField)?.length ?? 0) > 5
     ),
     filterableField
   );
 
 const filterableField = (field: FieldDefinitionNode) =>
   hasDirective(field, "amplienceFilterable");
+
+export const getTooManyDeliveryKeysReport = (types: ObjectTypeDefinitionNode[]) =>
+  getFieldsReport(
+    types.filter(
+      (type) => (type.fields?.filter(deliveryKeyField)?.length ?? 0) > 1
+    ),
+    deliveryKeyField
+  )
+
+export const getDeliveryKeyNotNullableStringReport = (types: ObjectTypeDefinitionNode[]) =>
+  getFieldsReport(
+    types.filter(
+      (type) => type.fields?.some((field) => deliveryKeyField(field) && !nullableStringField(field))
+    ),
+    (field) => deliveryKeyField(field) && !nullableStringField(field)
+  )
+
+const deliveryKeyField = (field: FieldDefinitionNode) =>
+  hasDirective(field, 'amplienceDeliveryKey')
+
+const nullableStringField = (field: FieldDefinitionNode) =>
+  (
+    field.type.kind === 'NamedType' &&
+    field.type.name.value === 'String'
+  )
 
 /**
  * Converts a type with filtered fields in a simple string report.

--- a/packages/plugin-json/test/testdata/base.graphql
+++ b/packages/plugin-json/test/testdata/base.graphql
@@ -26,6 +26,7 @@ type Base @amplienceContentType {
   union: Union
   linkedA: A @amplienceLink
   referencedB: B @amplienceReference
+  deliveryKeyWithDefaults: String @amplienceDeliveryKey
 }
 
 enum Enum {
@@ -41,6 +42,16 @@ type A @amplienceContentType {
 
 type B @amplienceContentType {
   b: String!
+}
+
+type DeliveryKeyExplicit @amplienceContentType {
+  a: String!
+  deliveryKeyExplicit: String
+    @amplienceDeliveryKey(
+      title: "explicit title"
+      description: "explicit description"
+      pattern: "explicit pattern"
+    )
 }
 
 type Inlined {

--- a/packages/plugin-json/test/testdata/expected/base.json
+++ b/packages/plugin-json/test/testdata/expected/base.json
@@ -10,6 +10,17 @@
   ],
   "type": "object",
   "properties": {
+    "_meta": {
+      "type": "object",
+      "title": "Delivery Key",
+      "properties": {
+        "deliveryKey": {
+          "type": "string",
+          "title": "Delivery Key",
+          "description": "Set a delivery key for this content item"
+        }
+      }
+    },
     "text": {
       "title": "Text",
       "type": "string",
@@ -187,6 +198,7 @@
     "video"
   ],
   "propertyOrder": [
+    "_meta",
     "text",
     "optionalText",
     "textList",

--- a/packages/plugin-json/test/testdata/expected/deliveryKeyExplicit.json
+++ b/packages/plugin-json/test/testdata/expected/deliveryKeyExplicit.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema-examples.com/base",
+    "title": "Base",
+    "description": "Base",
+    "allOf": [
+      {
+        "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
+      }
+    ],
+    "type": "object",
+    "properties": {
+      "_meta": {
+        "type": "object",
+        "title": "Delivery Key",
+        "properties": {
+            "deliveryKey": {
+                "type": "string",
+                "title": "explciit title",
+                "description": "explicit description",
+                "pattern": "explicit pattern"
+            }
+        }
+      },
+      "a": {
+        "title": "A",
+        "type": "string"
+      }
+    },
+    "required": ["a"],
+    "propertyOrder": ["_meta", "a"]
+  }
+  

--- a/packages/plugin-json/test/validate.test.ts
+++ b/packages/plugin-json/test/validate.test.ts
@@ -51,3 +51,70 @@ it("Throws Error: Types can have no more than 5 fields with '@amplienceFiltered'
     "Types can have no more than 5 fields with '@amplienceFiltered'.\n\ntype Test\n\ta\n\tb\n\tc\n\td\n\te\n\tf"
   );
 });
+
+it("Throws error: Types can only have 1 field with '@amplienceDeliveryKey'", () => {
+  const schema = buildASTSchema(gql`
+    ${print(schemaPrepend)}
+    type Test {
+      a: String @amplienceDeliveryKey
+      b: String @amplienceDeliveryKey
+    }
+  `);
+  expect(() => validate(schema, [], {}, "", [])).toThrow(
+    "Types can only have 1 field with '@amplienceDeliveryKey'.\n\ntype Test\n\ta\n\tb"
+  );
+});
+
+it.each([
+  gql`
+  type Test {
+    a: String! @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Int! @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Float! @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Boolean! @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Int @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Float @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type Test {
+    a: Boolean @amplienceDeliveryKey
+  }
+  `,
+  gql`
+  type ObjectType {
+    a: String!
+  }
+  type Test {
+    a: ObjectType @amplienceDeliveryKey
+  }
+  `
+])("Throws error: Fields with '@amplienceDeliveryKey' must be of Nullable type String", (testSchema) => {
+  const schema = buildASTSchema(gql`
+    ${print(schemaPrepend)}
+    ${print(testSchema)}
+  `);
+  expect(() => validate(schema, [], {}, "", [])).toThrow(
+    "Fields with '@amplienceDeliveryKey' must be of Nullable type String.\n\ntype Test\n\ta"
+  );
+});


### PR DESCRIPTION
Adds an `@amplienceDeliveryKey` directive for placing delivery key fields on custom Content Type forms in the required format, differing from regular fields.

[See documentation](https://amplience.com/developers/docs/dev-tools/guides-tutorials/delivery-keys/#including-the-deliverykey-property-in-a-content-type-schema)

The following schema:

```graphql
type MyContentType @amplienceContentType {
  deliveryKey: String
    @amplienceDeliveryKey(
      # Optional field title
      # Default value: 'Delivery Key'
      title: "example title"

      # Optional field description
      # Default value: 'Set a delivery key for this content item'
      description: "Format: delivery-key/format/requirement"

      # Optional field validation pattern
      pattern: "delivery-key/format/requirement"
    )

  a: Int!
}
```

Outputs:

```graphql
{
  "$id": "https://schema-examples.com/my-content-type",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "allOf": [
    { "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content" }
  ],
  "title": "My Content Type",
  "properties": {
    "a": { "title": "A", "type": "integer" },
    "_meta": {
      "type": "object",
      "title": "Delivery Key",
      "properties": {
        "deliveryKey": {
          "type": "string",
          "title": "example title",
          "description": "Format: delivery-key/format/requirement",
          "pattern": "delivery-key/format/requirement"
        }
      }
    }
  },
  "description": "My Content Type",
  "type": "object",
  "propertyOrder": ["_meta", "a"],
  "required": ["a"]
}
```