### PR TITLE
feat: validation for @amplienceExtension

### DIFF
--- a/.changeset/spotty-kangaroos-refuse.md
+++ b/.changeset/spotty-kangaroos-refuse.md
@@ -1,0 +1,5 @@
+---
+"amplience-graphql-codegen-json": minor
+---
+
+- add validation for amplience extension

--- a/packages/plugin-json/src/index.ts
+++ b/packages/plugin-json/src/index.ts
@@ -93,7 +93,7 @@ export const validate: PluginValidateFn<PluginConfig> = (
     getAmplienceExtensionNotNullableObjectReport(types);
   if (amplienceExtensionNotNullableObjectReport) {
     throw new Error(
-      `Fields with '@amplienceExtension' must be of a Nullable Object type.\n\n${amplienceExtensionNotNullableObjectReport}`,
+      `Fields with '@amplienceExtension' must be Nullable and of an Object type defined elsewhere in the schema.\n\n${amplienceExtensionNotNullableObjectReport}`,
     );
   }
 

--- a/packages/plugin-json/src/index.ts
+++ b/packages/plugin-json/src/index.ts
@@ -13,6 +13,8 @@ import type { ObjectTypeDefinitionNode } from "graphql";
 import { dirname } from "path";
 import { contentTypeSchemaBody } from "./lib/amplience-schema-transformers";
 import {
+  getAmplienceExtensionNotNullableObjectReport,
+  getAmplienceExtensionReferencesAmplienceContentTypeReport,
   getDeliveryKeyNotNullableStringReport,
   getObjectTypeDefinitions,
   getRequiredLocalizedFieldsReport,
@@ -84,6 +86,22 @@ export const validate: PluginValidateFn<PluginConfig> = (
   if (deliveryKeyNotNullableStringReport) {
     throw new Error(
       `Fields with '@amplienceDeliveryKey' must be of Nullable type String.\n\n${deliveryKeyNotNullableStringReport}`,
+    );
+  }
+
+  const amplienceExtensionNotNullableObjectReport =
+    getAmplienceExtensionNotNullableObjectReport(types);
+  if (amplienceExtensionNotNullableObjectReport) {
+    throw new Error(
+      `Fields with '@amplienceExtension' must be of a Nullable Object type.\n\n${amplienceExtensionNotNullableObjectReport}`,
+    );
+  }
+
+  const amplienceExtensionOnAmplienceContentTypeReport =
+    getAmplienceExtensionReferencesAmplienceContentTypeReport(types);
+  if (amplienceExtensionOnAmplienceContentTypeReport) {
+    throw new Error(
+      `Types referenced by fields with '@amplienceExtension' must not have '@amplienceContentType' directive.\n\n${amplienceExtensionOnAmplienceContentTypeReport}`,
     );
   }
 };

--- a/packages/plugin-json/src/lib/validation.ts
+++ b/packages/plugin-json/src/lib/validation.ts
@@ -92,11 +92,12 @@ export const getAmplienceExtensionNotNullableObjectReport = (
         type.fields?.some(
           (field) =>
             isAmplienceExtensionField(field) &&
-            !isNullableObjectField(field.type),
+            !isNullableObjectField(field.type, types),
         ),
     ),
     (field) =>
-      isAmplienceExtensionField(field) && !isNullableObjectField(field.type),
+      isAmplienceExtensionField(field) &&
+      !isNullableObjectField(field.type, types),
   );
 
 // @amplienceExtension referencing an @amplienceContentType produces odd behavior we want to avoid
@@ -109,22 +110,25 @@ export const getAmplienceExtensionReferencesAmplienceContentTypeReport = (
         type.fields?.some(
           (field) =>
             isAmplienceExtensionField(field) &&
-            isNullableObjectField(field.type) &&
+            isNullableObjectField(field.type, types) &&
             isAmplienceContentTypeField(field.type, types),
         ),
     ),
     (field) =>
       isAmplienceExtensionField(field) &&
-      isNullableObjectField(field.type) &&
+      isNullableObjectField(field.type, types) &&
       isAmplienceContentTypeField(field.type, types),
   );
 
 const isAmplienceExtensionField = (field: FieldDefinitionNode) =>
   hasDirective(field, "amplienceExtension");
 
-const isNullableObjectField = (type: TypeNode): type is NamedTypeNode =>
-  type.kind === "NamedType" &&
-  !["Int", "Float", "String", "Boolean", "ID"].includes(type.name.value);
+const isNullableObjectField = (
+  fieldType: TypeNode,
+  allTypes: ObjectTypeDefinitionNode[],
+): fieldType is NamedTypeNode =>
+  fieldType.kind === "NamedType" &&
+  allTypes.some((type) => type.name.value === fieldType.name.value);
 
 const isAmplienceContentTypeField = (
   fieldType: NamedTypeNode,

--- a/packages/plugin-json/src/lib/validation.ts
+++ b/packages/plugin-json/src/lib/validation.ts
@@ -3,10 +3,11 @@ import {
   isObjectTypeDefinitionNode,
   isValue,
 } from "amplience-graphql-codegen-common";
-import type {
-  FieldDefinitionNode,
-  GraphQLSchema,
-  ObjectTypeDefinitionNode,
+import type { NamedTypeNode, TypeNode } from "graphql";
+import {
+  type FieldDefinitionNode,
+  type GraphQLSchema,
+  type ObjectTypeDefinitionNode,
 } from "graphql";
 
 export const getObjectTypeDefinitions = (
@@ -81,6 +82,62 @@ const isDeliveryKeyField = (field: FieldDefinitionNode) =>
 
 const isNullableStringField = (field: FieldDefinitionNode) =>
   field.type.kind === "NamedType" && field.type.name.value === "String";
+
+export const getAmplienceExtensionNotNullableObjectReport = (
+  types: ObjectTypeDefinitionNode[],
+): string =>
+  getFieldsReport(
+    types.filter(
+      (type) =>
+        type.fields?.some(
+          (field) =>
+            isAmplienceExtensionField(field) &&
+            !isNullableObjectField(field.type),
+        ),
+    ),
+    (field) =>
+      isAmplienceExtensionField(field) && !isNullableObjectField(field.type),
+  );
+
+// @amplienceExtension referencing an @amplienceContentType produces odd behavior we want to avoid
+export const getAmplienceExtensionReferencesAmplienceContentTypeReport = (
+  types: ObjectTypeDefinitionNode[],
+): string =>
+  getFieldsReport(
+    types.filter(
+      (type) =>
+        type.fields?.some(
+          (field) =>
+            isAmplienceExtensionField(field) &&
+            isNullableObjectField(field.type) &&
+            isAmplienceContentTypeField(field.type, types),
+        ),
+    ),
+    (field) =>
+      isAmplienceExtensionField(field) &&
+      isNullableObjectField(field.type) &&
+      isAmplienceContentTypeField(field.type, types),
+  );
+
+const isAmplienceExtensionField = (field: FieldDefinitionNode) =>
+  hasDirective(field, "amplienceExtension");
+
+const isNullableObjectField = (type: TypeNode): type is NamedTypeNode =>
+  type.kind === "NamedType" &&
+  !["Int", "Float", "String", "Boolean", "ID"].includes(type.name.value);
+
+const isAmplienceContentTypeField = (
+  fieldType: NamedTypeNode,
+  allTypes: ObjectTypeDefinitionNode[],
+) => {
+  const referencedType = allTypes.find(
+    (t) => t.name.value === fieldType.name.value,
+  );
+
+  return referencedType
+    ? hasDirective(referencedType, "amplienceContentType")
+    : false;
+};
 
 /**
  * Converts a type with filtered fields in a simple string report.

--- a/packages/plugin-json/test/validate.test.ts
+++ b/packages/plugin-json/test/validate.test.ts
@@ -187,15 +187,21 @@ it.each([
       a: [ObjectType!]! @amplienceExtension(name: "test-extension")
     }
   `,
+  gql`
+    scalar Date
+    type Test {
+      a: Date @amplienceExtension(name: "test-extension")
+    }
+  `,
 ])(
-  "Throw error: Fields with '@amplienceExtension' must be of a Nullable Object type",
+  "Throw error: Fields with '@amplienceExtension' must be Nullable and of an Object type defined elsewhere in the schema",
   (testSchema) => {
     const schema = buildASTSchema(gql`
       ${print(schemaPrepend)}
       ${print(testSchema)}
     `);
     expect(() => validate(schema, [], {}, "", [])).toThrow(
-      "Fields with '@amplienceExtension' must be of a Nullable Object type.\n\ntype Test\n\ta",
+      "Fields with '@amplienceExtension' must be Nullable and of an Object type defined elsewhere in the schema.\n\ntype Test\n\ta",
     );
   },
 );

--- a/packages/plugin-json/test/validate.test.ts
+++ b/packages/plugin-json/test/validate.test.ts
@@ -121,3 +121,96 @@ it.each([
     );
   },
 );
+
+it.each([
+  gql`
+    type Test {
+      a: String! @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Int! @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Float! @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Boolean! @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: String @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Int @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Float @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type Test {
+      a: Boolean @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type ObjectType {
+      a: String!
+    }
+    type Test {
+      a: [ObjectType] @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type ObjectType {
+      a: String!
+    }
+    type Test {
+      a: ObjectType! @amplienceExtension(name: "test-extension")
+    }
+  `,
+  gql`
+    type ObjectType {
+      a: String!
+    }
+    type Test {
+      a: [ObjectType!]! @amplienceExtension(name: "test-extension")
+    }
+  `,
+])(
+  "Throw error: Fields with '@amplienceExtension' must be of a Nullable Object type",
+  (testSchema) => {
+    const schema = buildASTSchema(gql`
+      ${print(schemaPrepend)}
+      ${print(testSchema)}
+    `);
+    expect(() => validate(schema, [], {}, "", [])).toThrow(
+      "Fields with '@amplienceExtension' must be of a Nullable Object type.\n\ntype Test\n\ta",
+    );
+  },
+);
+
+it("Throws error: Types referenced by fields with '@amplienceExtension' must not have '@amplienceContentType' directive", () => {
+  const schema = buildASTSchema(gql`
+    ${print(schemaPrepend)}
+    type ReferencedType @amplienceContentType {
+      a: String!
+    }
+    type Test {
+      a: ReferencedType @amplienceExtension(name: "test-extension")
+    }
+  `);
+  expect(() => validate(schema, [], {}, "", [])).toThrow(
+    "Types referenced by fields with '@amplienceExtension' must not have '@amplienceContentType' directive.\n\ntype Test\n\ta",
+  );
+});


### PR DESCRIPTION
More validation for @amplienceExtension:
- must be of Nullable Object type (eg not `String!` or `String` or `ObjectType!`)
- must not reference an object type annotated with `@amplienceContentType`