### PR TITLE
feat: add optional custom label directive

### DIFF
--- a/.changeset/lazy-clocks-sparkle.md
+++ b/.changeset/lazy-clocks-sparkle.md
@@ -1,0 +1,6 @@
+---
+"amplience-graphql-codegen-terraform": minor
+"amplience-graphql-codegen-common": minor
+---
+
+Add optional directive for custom label override

--- a/packages/common/src/directives.ts
+++ b/packages/common/src/directives.ts
@@ -41,5 +41,6 @@ export const schemaPrepend = gql`
     visualizations: Boolean
     icon: String
     autoSync: Boolean
+    label: String
   ) on OBJECT
 `;

--- a/packages/plugin-terraform/examples/output/example.tf
+++ b/packages/plugin-terraform/examples/output/example.tf
@@ -176,7 +176,7 @@ resource "amplience_content_type_schema" "test_custom_label" {
 
 resource "amplience_content_type" "test_custom_label" {
   content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
-  label            = "Test Custom Label"
+  label            = "Test Altered Custom Label"
   status           = "ACTIVE"
 }
 

--- a/packages/plugin-terraform/examples/output/example.tf
+++ b/packages/plugin-terraform/examples/output/example.tf
@@ -166,3 +166,21 @@ resource "amplience_content_type_assignment" "test_visualizations" {
   repository_id   = data.amplience_content_repository.website1.id
 }
 
+
+resource "amplience_content_type_schema" "test_custom_label" {
+  body             = file("${path.module}/schemas/test-custom-label.json")
+  schema_id        = "https://schema-examples.com/test-custom-label"
+  validation_level = "CONTENT_TYPE"
+  auto_sync        = true
+}
+
+resource "amplience_content_type" "test_custom_label" {
+  content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
+  label            = "Test Custom Label"
+  status           = "ACTIVE"
+}
+
+resource "amplience_content_type_assignment" "test_custom_label" {
+  content_type_id = amplience_content_type.test_custom_label.id
+  repository_id   = data.amplience_content_repository.website1.id
+}

--- a/packages/plugin-terraform/src/lib/visitor.ts
+++ b/packages/plugin-terraform/src/lib/visitor.ts
@@ -75,11 +75,15 @@ export const createObjectTypeVisitor =
       ? maybeDirectiveValue<StringValueNode>(directive, "icon")?.value
       : undefined;
 
+    const label = directive
+      ? maybeDirectiveValue<StringValueNode>(directive, "label")?.value
+      : undefined;
+
     const dynamicVisualization = visualization?.find(hasProperty("for_each"));
 
     const contentType = tfg.resource("amplience_content_type", name, {
       content_type_uri: schema.attr("schema_id"),
-      label: capitalCase(node.name.value),
+      label: label ? label : capitalCase(node.name.value),
       icon: iconUrl ? { size: 256, url: iconUrl } : undefined,
       status: "ACTIVE",
       'dynamic"visualization"':

--- a/packages/plugin-terraform/src/lib/visitor.ts
+++ b/packages/plugin-terraform/src/lib/visitor.ts
@@ -83,7 +83,7 @@ export const createObjectTypeVisitor =
 
     const contentType = tfg.resource("amplience_content_type", name, {
       content_type_uri: schema.attr("schema_id"),
-      label: label ? label : capitalCase(node.name.value),
+      label: label ?? capitalCase(node.name.value),
       icon: iconUrl ? { size: 256, url: iconUrl } : undefined,
       status: "ACTIVE",
       'dynamic"visualization"':

--- a/packages/plugin-terraform/test/testdata/base.graphql
+++ b/packages/plugin-terraform/test/testdata/base.graphql
@@ -31,6 +31,10 @@ type TestNoAutoSync @amplienceContentType {
   name: String
 }
 
+type TestCustomLabel @amplienceContentType(label: "Test Custom Label") {
+  name: String
+}
+
 type NotATest {
   name: String!
 }

--- a/packages/plugin-terraform/test/testdata/base.graphql
+++ b/packages/plugin-terraform/test/testdata/base.graphql
@@ -31,7 +31,7 @@ type TestNoAutoSync @amplienceContentType {
   name: String
 }
 
-type TestCustomLabel @amplienceContentType(label: "Test Custom Label") {
+type TestCustomLabel @amplienceContentType(label: "Test Altered Custom Label") {
   name: String
 }
 

--- a/packages/plugin-terraform/test/testdata/base_repo_for_each.graphql
+++ b/packages/plugin-terraform/test/testdata/base_repo_for_each.graphql
@@ -26,7 +26,7 @@ type TestNoAutoSync @amplienceContentType {
   name: String
 }
 
-type TestCustomLabel @amplienceContentType(label: "Test Custom Label") {
+type TestCustomLabel @amplienceContentType(label: "Test Altered Custom Label") {
   name: String
 }
 

--- a/packages/plugin-terraform/test/testdata/base_repo_for_each.graphql
+++ b/packages/plugin-terraform/test/testdata/base_repo_for_each.graphql
@@ -26,6 +26,10 @@ type TestNoAutoSync @amplienceContentType {
   name: String
 }
 
+type TestCustomLabel @amplienceContentType(label: "Test Custom Label") {
+  name: String
+}
+
 type NotATest {
   name: String!
 }

--- a/packages/plugin-terraform/test/testdata/expected/base.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base.tf
@@ -215,7 +215,7 @@ auto_sync = true
 
 resource "amplience_content_type" "test_custom_label"{
 content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
-label = "Test Custom Label"
+label = "Test Altered Custom Label"
 status = "ACTIVE"
 }
 

--- a/packages/plugin-terraform/test/testdata/expected/base.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base.tf
@@ -205,3 +205,21 @@ resource "amplience_content_type_assignment" "test_no_auto_sync"{
 content_type_id = amplience_content_type.test_no_auto_sync.id
 repository_id = data.amplience_content_repository.website1.id
 }
+
+resource "amplience_content_type_schema" "test_custom_label"{
+body = file("${path.module}/schemas/test-custom-label.json")
+schema_id = "https://schema-examples.com/test-custom-label"
+validation_level = "CONTENT_TYPE"
+auto_sync = true
+}
+
+resource "amplience_content_type" "test_custom_label"{
+content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
+label = "Test Custom Label"
+status = "ACTIVE"
+}
+
+resource "amplience_content_type_assignment" "test_custom_label"{
+content_type_id = amplience_content_type.test_custom_label.id
+repository_id = data.amplience_content_repository.website1.id
+}

--- a/packages/plugin-terraform/test/testdata/expected/base_repo_for_each.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base_repo_for_each.tf
@@ -178,3 +178,22 @@ for_each = var.variables["CONTENT_REPO_MAP"]
 content_type_id = amplience_content_type.test_no_auto_sync.id
 repository_id = each.value
 }
+
+resource "amplience_content_type_schema" "test_custom_label"{
+body = file("${path.module}/schemas/test-custom-label.json")
+schema_id = "https://schema-examples.com/test-custom-label"
+validation_level = "CONTENT_TYPE"
+auto_sync = true
+}
+
+resource "amplience_content_type" "test_custom_label"{
+content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
+label = "Test Custom Label"
+status = "ACTIVE"
+}
+
+resource "amplience_content_type_assignment" "test_custom_label"{
+for_each = var.variables["CONTENT_REPO_MAP"]
+content_type_id = amplience_content_type.test_custom_label.id
+repository_id = each.value
+}

--- a/packages/plugin-terraform/test/testdata/expected/base_repo_for_each.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base_repo_for_each.tf
@@ -188,7 +188,7 @@ auto_sync = true
 
 resource "amplience_content_type" "test_custom_label"{
 content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
-label = "Test Custom Label"
+label = "Test Altered Custom Label"
 status = "ACTIVE"
 }
 

--- a/packages/plugin-terraform/test/testdata/expected/base_without_provider.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base_without_provider.tf
@@ -207,7 +207,7 @@ auto_sync = true
 
 resource "amplience_content_type" "test_custom_label"{
 content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
-label = "Test Custom Label"
+label = "Test Altered Custom Label"
 status = "ACTIVE"
 }
 

--- a/packages/plugin-terraform/test/testdata/expected/base_without_provider.tf
+++ b/packages/plugin-terraform/test/testdata/expected/base_without_provider.tf
@@ -197,3 +197,21 @@ resource "amplience_content_type_assignment" "test_no_auto_sync"{
 content_type_id = amplience_content_type.test_no_auto_sync.id
 repository_id = data.amplience_content_repository.website1.id
 }
+
+resource "amplience_content_type_schema" "test_custom_label"{
+body = file("${path.module}/schemas/test-custom-label.json")
+schema_id = "https://schema-examples.com/test-custom-label"
+validation_level = "CONTENT_TYPE"
+auto_sync = true
+}
+
+resource "amplience_content_type" "test_custom_label"{
+content_type_uri = amplience_content_type_schema.test_custom_label.schema_id
+label = "Test Custom Label"
+status = "ACTIVE"
+}
+
+resource "amplience_content_type_assignment" "test_custom_label"{
+content_type_id = amplience_content_type.test_custom_label.id
+repository_id = data.amplience_content_repository.website1.id
+}


### PR DESCRIPTION
# Current behaviour

Normally the label for a content type is simply a Capital Case version of the PascalCase name of the content type.

![image](https://github.com/user-attachments/assets/6ffd16a4-e7f8-4da0-be31-18d91ff79c14)

# New Behaviour

This will continue to happen _unless_ the developer adds the optional `label` directive to have custom control over setting the label

## Scenarios

Sometimes it's useful/required to be able to override the label, for instance...

1. During the deprecating of a content type
  ![image](https://github.com/user-attachments/assets/6548bb7f-3294-4b30-992a-c6205d76d1a0)

2. To make user-friendly edits to an existing content type's label (Non-technical content editors will see these labels) without breaking the underlying schema or data patterns.
  ![image](https://github.com/user-attachments/assets/786d3f02-146d-4764-bb2b-5b8e6c34af8c)

# Amplience Context

We've talked to Benjamin Bergens from amplience about this, who recommended we should change the label. But seeing as we do everything through Terraform, we need to update the terraform plugin to enable this capability.